### PR TITLE
fix: Clear Database機能の廃止

### DIFF
--- a/src/backend/handler.ts
+++ b/src/backend/handler.ts
@@ -28,7 +28,7 @@ import { getDatabasePath, getLogPath } from './paths'
 import logger from './logger'
 import { streamText, abortStream, listAvailableModel, testConnection } from './ai'
 import { FACTORY } from './ai/factory'
-import { close, db, destroy } from './db'
+import { db } from './db'
 import { mcpManager } from './mcp'
 import { getProxySettings as loadProxySettings, setProxySettings as saveProxySettings, getSystemProxySettings as loadSystemProxySettings } from './settings/proxy'
 import { getCertificateSettings as loadCertificateSettings, setCertificateSettings as saveCertificateSettings, getSystemCertificateSettings as loadSystemCertificateSettings } from './settings/certificate'
@@ -76,12 +76,6 @@ export class Handler {
 
   async clearSetting(key: string): Promise<Result<void>> {
     await clearSetting(key)
-    return ok(undefined)
-  }
-
-  async clearDatabase(): Promise<Result<void, string>> {
-    close(db)
-    destroy()
     return ok(undefined)
   }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -195,7 +195,6 @@ export interface RendererBackendAPI {
   getSetting: (key: string) => Promise<Result<unknown>>
   setSetting: (key: string, value: unknown) => Promise<Result<void>>
   clearSetting: (key: string) => Promise<Result<void>>
-  clearDatabase: () => Promise<Result<void>>
   getDatabasePath: () => Promise<Result<string>>
   getLogPath: () => Promise<Result<string>>
   streamAIText: (messages: AIMessage[], options?: StreamAIOptions) => Promise<Result<string>>

--- a/src/preload/server.ts
+++ b/src/preload/server.ts
@@ -17,7 +17,6 @@ export class Server {
     getSetting: (...args) => this._invoke('getSetting', ...args),
     setSetting: (...args) => this._invoke('setSetting', ...args),
     clearSetting: (...args) => this._invoke('clearSetting', ...args),
-    clearDatabase: (...args) => this._invoke('clearDatabase', ...args),
     getDatabasePath: (...args) => this._invoke('getDatabasePath', ...args),
     getLogPath: (...args) => this._invoke('getLogPath', ...args),
     streamAIText: (...args) => this._invoke('streamAIText', ...args),

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { ArrowLeft, Trash2, FolderOpen, Wifi, Loader2, CheckCircle, XCircle } from 'lucide-react'
+import { ArrowLeft, FolderOpen, Wifi, Loader2, CheckCircle, XCircle } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 import { isOk, isError } from '@common/result'
 import { logger } from '@renderer/lib/logger'
@@ -9,19 +9,8 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-  CardDescription,
-  CardFooter
+  CardDescription
 } from '@renderer/components/ui/card'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle
-} from '@renderer/components/ui/alert-dialog'
 import { AISettingsV2Component } from './AISettings'
 import { ProxySettings } from './ProxySettings'
 import { MCPSettings } from './MCPSettings'
@@ -32,11 +21,8 @@ interface SettingsProps {
 }
 
 export function Settings({ onBack }: SettingsProps): React.JSX.Element {
-  const [isClearingDatabase, setIsClearingDatabase] = useState(false)
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
   const [databasePath, setDatabasePath] = useState<string>('')
   const [logPath, setLogPath] = useState<string>('')
-  const [clearDbConfirmOpen, setClearDbConfirmOpen] = useState(false)
 
   // Connection test state
   const [isTesting, setIsTesting] = useState(false)
@@ -61,13 +47,6 @@ export function Settings({ onBack }: SettingsProps): React.JSX.Element {
         setLogPath(logPathResult.value)
       } else {
         logger.error('Failed to get log path:', logPathResult.error)
-      }
-
-      if (isError(dbPathResult) || isError(logPathResult)) {
-        setMessage({
-          type: 'error',
-          text: 'Failed to load some file paths'
-        })
       }
     }
 
@@ -109,29 +88,6 @@ export function Settings({ onBack }: SettingsProps): React.JSX.Element {
       </div>
     </div>
   )
-
-  const handleClearDatabase = async (): Promise<void> => {
-    setIsClearingDatabase(true)
-    setMessage(null)
-
-    const result = await window.backend.clearDatabase()
-
-    if (isOk(result)) {
-      setMessage({
-        type: 'success',
-        text: 'Database cleared successfully!'
-      })
-    } else {
-      logger.error('Failed to clear database:', result.error)
-      setMessage({
-        type: 'error',
-        text: 'Failed to clear database. Please try again.'
-      })
-    }
-
-    setIsClearingDatabase(false)
-    setClearDbConfirmOpen(false)
-  }
 
   const testConnection = useCallback(async (): Promise<void> => {
     setIsTesting(true)
@@ -198,7 +154,7 @@ export function Settings({ onBack }: SettingsProps): React.JSX.Element {
     <div className="h-screen bg-gray-50 p-8 overflow-auto">
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
-          <Button variant="ghost" size="icon" onClick={onBack} disabled={isClearingDatabase}>
+          <Button variant="ghost" size="icon" onClick={onBack}>
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <h1 className="text-4xl font-bold text-gray-900">Settings</h1>
@@ -295,66 +251,8 @@ export function Settings({ onBack }: SettingsProps): React.JSX.Element {
               </div>
             </CardContent>
           </Card>
-
-          <Card className="shadow-sm">
-            <CardHeader>
-              <CardTitle className="text-red-600">Danger Zone</CardTitle>
-              <CardDescription>
-                Irreversible actions that will permanently modify your application data.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div>
-                <h3 className="font-medium text-gray-900 mb-2">Clear Database</h3>
-                <p className="text-sm text-gray-600 mb-4">
-                  This will permanently delete all data from the database and close the application.
-                  You will need to restart the application manually. This action cannot be undone.
-                </p>
-              </div>
-            </CardContent>
-            <CardFooter>
-              <Button
-                variant="destructive"
-                onClick={() => setClearDbConfirmOpen(true)}
-                disabled={isClearingDatabase}
-                className="flex items-center gap-2"
-              >
-                <Trash2 className="h-4 w-4" />
-                {isClearingDatabase ? 'Clearing...' : 'Clear Database'}
-              </Button>
-            </CardFooter>
-          </Card>
         </div>
-
-        {message && (
-          <div
-            className={`mt-6 p-4 rounded-md ${
-              message.type === 'success'
-                ? 'bg-green-50 text-green-800 border border-green-200'
-                : 'bg-red-50 text-red-800 border border-red-200'
-            }`}
-          >
-            {message.text}
-          </div>
-        )}
       </div>
-
-      <AlertDialog open={clearDbConfirmOpen} onOpenChange={setClearDbConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Clear Database</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete all data from the database and close the application. You
-              will need to restart the application manually. This action cannot be undone. Are you
-              sure you want to continue?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleClearDatabase}>Clear Database</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
Removes the Clear Database feature from the Settings page as it had limited practical utility and caused issues with proper re-entry processing after execution. Developers can use 'pnpm run db:reset' as an alternative.

- Remove Danger Zone card from Settings UI
- Remove clearDatabase API from backend, preload, and types
- Resolves #20