### PR TITLE
fix: Prevent before-quit handler from blocking updater installer launch

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,7 +58,13 @@ function main() {
   })
 
   app.on('before-quit', async (event) => {
-    console.log('before-quit')
+    // Allow updater to quit and install without interference
+    if (server?.getUpdater().isQuittingToInstall()) {
+      logger.info('before-quit: Updater is installing, allowing quit')
+      return
+    }
+
+    logger.info('before-quit: Shutting down gracefully')
     event.preventDefault()
     await server!.shutdown()
     app.exit(0)


### PR DESCRIPTION
The before-quit handler was unconditionally calling event.preventDefault(), which could interfere with electron-updater's quitAndInstall() process.

Changes:
- Add isQuittingToInstall flag to track updater install state
- Update before-quit handler to skip preventDefault when updater is installing
- Remove before-quit listener in quitAndInstall to prevent interference
- Replace console.log with proper logger calls for consistency

Fixes #24