### PR TITLE
Ensure external hyperlinks open outside the app

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -61,8 +61,17 @@ export class Server {
     })
 
     this._mainWindow.webContents.on('will-navigate', (event, url) => {
-      event.preventDefault()
-      shell.openExternal(url)
+      // Allow internal navigation (file://, localhost), block external URLs
+      const isInternal =
+        url.startsWith('file://') ||
+        url.startsWith('http://localhost:') ||
+        url.startsWith('http://127.0.0.1:')
+
+      if (!isInternal) {
+        // Open external URLs in system browser
+        event.preventDefault()
+        shell.openExternal(url)
+      }
     })
 
     // HMR for renderer base on electron-vite cli.


### PR DESCRIPTION
## Summary
- open navigations from the main window in the system browser to avoid trapping users in the app window

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691985c60ab48330b235a991dbd2cd40)